### PR TITLE
Remove backticks; add double-quotes

### DIFF
--- a/youtube.sh
+++ b/youtube.sh
@@ -6,8 +6,8 @@
 # The script will create a file with all the youtube ads found in hostsearch and from the logs of the Pi-hole
 # it will append the list into a file called blacklist.txt'/etc/pihole/blacklist.txt'
 
-piholeIPV4=`hostname -I |awk '{print $1}'`
-piholeIPV6=`hostname -I |awk '{print $2}'`
+piholeIPV4=$(hostname -I |awk '{print $1}')
+piholeIPV6=$(hostname -I |awk '{print $2}')
 
 
 balckListFile='/etc/pihole/black.list'
@@ -27,8 +27,8 @@ sudo curl 'https://api.hackertarget.com/hostsearch/?q=googlevideo.com' \
 
 # collecting the youtube ads website from the pihole logs and added it the blacklist.txt
 #Also, Collect the youtube videos from the Pihole logs 
-sudo cat /var/log/pihole.log* |grep '^r[0-9]*-.*.googlevideo'|grep -v '\-\-\-sn\-n4v7' |awk -v a=$piholeIPV4 '{print a " " $8}'|sort |uniq>> $balckListFile
-sudo cat /var/log/pihole.log* |grep '^r[0-9]*-.*.googlevideo'|grep -v '\-\-\-sn\-n4v7' |awk -v a=$piholeIPV6 '{print a " " $8}'|sort |uniq>> $balckListFile
+sudo cat /var/log/pihole.log* |grep '^r[0-9]*-.*.googlevideo'|grep -v '\-\-\-sn\-n4v7' |awk -v a="$piholeIPV4" '{print a " " $8}'|sort |uniq>> $balckListFile
+sudo cat /var/log/pihole.log* |grep '^r[0-9]*-.*.googlevideo'|grep -v '\-\-\-sn\-n4v7' |awk -v a="$piholeIPV6" '{print a " " $8}'|sort |uniq>> $balckListFile
 sudo cat /var/log/pihole.log* |grep '^r[0-9]*-.*.googlevideo'|grep -v '\-\-\-sn\-n4v7' |awk '{print $8}'|sort |uniq>> $blacklist
 sudo cat /var/log/pihole.log* |awk '{print $6}'|grep '^r[0-9]*-.*.googlevideo'|grep -v '\-\-\-sn\-n4v7' |sort |uniq>> $blacklist
 wait 


### PR DESCRIPTION
Backticking is a legacy feature of Bash. The modern method is to use "$()" instead. Also, double-quoting variables will prevent globbing and word splitting. This can have nasty side effects. :)

Awesome project!