### PR TITLE
removed unnecessary dpkg command, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Buy me a coffee via paypal
 - Please wipe your blacklist by ``` sudo rm /etc/pihole/black* ``` or use the command ```sudo pihole -f ```
 - because my previous development caused to block the youtube video itself
 - The new script has been working great for me for the last couple days
+
+# Dependencies
+You need `gawk` to run youtube.sh (to remove the duplicate records from your blacklist when the script updates).
+
 # Option 1 : add the link to your gravity block list 
 https://github.com/kboghdady/youTube_ads_4_pi-hole/blob/master/youtubelist.txt
 

--- a/youtube.sh
+++ b/youtube.sh
@@ -23,12 +23,6 @@ sudo curl 'https://raw.githubusercontent.com/kboghdady/youTube_ads_4_pi-hole/mas
 sudo curl 'https://raw.githubusercontent.com/kboghdady/youTube_ads_4_pi-hole/master/black.list' |awk -v a=$piholeIPV4 '{print a " " $1}'|sort |uniq>>$blackListFile
 sudo curl 'https://raw.githubusercontent.com/kboghdady/youTube_ads_4_pi-hole/master/black.list' |awk -v a=$piholeIPV6 '{print a " " $1}'|sort |uniq>>$blackListFile
 
-
-wait 
-
-# check to see if gawk is installed. if not it will install it
-dpkg -l | grep -qw gawk || sudo apt-get install gawk -y
-
 wait 
 # remove the duplicate records in place
 gawk -i inplace '!a[$0]++' $blackListFile


### PR DESCRIPTION
Not all PiHoles are run on Debian-based distros, and it's kind of a waste of computation to be running dpkg constantly when gawk only needs to be installed once. I just listed it as a dependency and removed the constant dpkg calls.